### PR TITLE
fix: changing the acme_sh_*_cmd variables also modifies the sudoers command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are some defaults that control behavior:
 
     acme_sh_certs_public_dir: /etc/nginx/certs
     acme_sh_certs_private_dir: /etc/nginx/private
-    acme_sh_reload_cmd: sudo /bin/systemctl reload nginx
+    acme_sh_reload_cmd: /bin/systemctl reload nginx
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ acme_sh_cert_fullchain_file: "{{ acme_sh_certs_public_dir }}/{{ acme_sh_first_su
 acme_sh_cert_ca_file: "{{ acme_sh_certs_public_dir }}/ca.cer"
 acme_sh_cert_key_file: "{{ acme_sh_certs_private_dir }}/{{ acme_sh_first_subject }}.key"
 
-acme_sh_restart_cmd: sudo /bin/systemctl restart nginx
-acme_sh_reload_cmd: sudo /bin/systemctl reload nginx
+acme_sh_restart_cmd: /bin/systemctl restart nginx
+acme_sh_reload_cmd: /bin/systemctl reload nginx
 
 acme_sh_force_install: False

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -44,7 +44,7 @@
       --key-file {{ acme_sh_cert_key_file }}
       --fullchain-file {{ acme_sh_cert_fullchain_file }}
       --ca-file {{ acme_sh_cert_ca_file }}
-      --reloadcmd "{{ acme_sh_reload_cmd if (cert is defined and cert.stat.exists) else acme_sh_restart_cmd }}"
+      --reloadcmd "sudo {{ acme_sh_reload_cmd if (cert is defined and cert.stat.exists) else acme_sh_restart_cmd }}"
       --debug
   args:
     chdir: "{{ acme_sh_dir }}"

--- a/templates/letsencrypt_restart_nginx.j2
+++ b/templates/letsencrypt_restart_nginx.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
 Defaults !requiretty
-Cmnd_Alias ACME_NGINX_RELOAD = /bin/systemctl reload nginx
-Cmnd_Alias ACME_NGINX_RESTART = /bin/systemctl restart nginx
+Cmnd_Alias ACME_NGINX_RELOAD = {{ acme_sh_reload_cmd }}
+Cmnd_Alias ACME_NGINX_RESTART = {{ acme_sh_restart_cmd }}
 {{ acme_sh_user }} ALL=(root) NOPASSWD: ACME_NGINX_RELOAD, ACME_NGINX_RESTART


### PR DESCRIPTION
Hi!
I'm using your role with a Gitlab installation and I noticed that changing the variables `acme_sh_restart_cmd` and `acme_sh_reload_cmd` didn't change the sudoers file so the `acme_sh_user` couldn't actually use those commands.